### PR TITLE
fix month to one digit

### DIFF
--- a/bin/calendar
+++ b/bin/calendar
@@ -5,7 +5,7 @@ current_day=$(date +"%e")
 current_month=$(date +"%m")
 current_year=$(date +"%Y")
 
-month=$(date +"%m")
+month=$(date +"%-m")
 year=$(date +"%Y")
 previous_month="◀"
 next_month="▶"


### PR DESCRIPTION
Fix this issue : can't navigate to previous or next month.
I had this error : 
./calendar: ligne 85: ((: 09 : valeur trop grande pour la base (le symbole erroné est « 09 »)
./calendar: ligne 86: [[: 09 : valeur trop grande pour la base (le symbole erroné est « 09 »)